### PR TITLE
implement `auto_category` argument for `add_item_to_list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ Toggle a list item's crossed off property based on `cross_off`
 
 ---
 
-```def add_item_to_list(list_id, value, category="uncategorized")```
+```def add_item_to_list(list_id, value, category="uncategorized", auto_category=False)```
 
-Adds a new item to a given list/category
+Adds a new item to a given list/category. Use `auto_category` instead of `category` to let
+Our Groceries apply the default category for this item.
 
 ---
 

--- a/ourgroceries/__init__.py
+++ b/ourgroceries/__init__.py
@@ -160,7 +160,7 @@ class OurGroceries():
         }
         return await self._post(ACTION_ITEM_CROSSED_OFF, other_payload)
 
-    async def add_item_to_list(self, list_id, value, category="uncategorized"):
+    async def add_item_to_list(self, list_id, value, category="uncategorized", auto_category=False):
         """Add a new item to a list."""
         _LOGGER.debug('ourgroceries add_item_to_list')
         other_payload = {
@@ -168,6 +168,8 @@ class OurGroceries():
             ATTR_ITEM_VALUE: value,
             ATTR_ITEM_CATEGORY: category,
         }
+        if auto_category:
+            other_payload.pop(ATTR_ITEM_CATEGORY, None)
         return await self._post(ACTION_ITEM_ADD, other_payload)
 
     async def remove_item_from_list(self, list_id, item_id):


### PR DESCRIPTION
This adds a new argument `auto_category` to the `add_item_to_list` method, allowing the caller to mimic the GUI behavior. When the category is omitted from the request, the backend will assign a default category (seems to be the category that item was most recently assigned to).

This is *not* how I would implement this feature if I were starting from scratch, but I assume you want to preserve existing behavior.

If I were to implement this feature with no regard for existing users, I would change the default value of the `category` argument to `None` to trigger the automatic behavior and avoid adding the new keyword argument. Let me know if you prefer that and I will redo it.

Side note, on the topic of the `category` argument: the default value `"uncategorized"` implies that it accepts the name of a category. However, to work as expected it must be a `categoryId`. When the value provided is an invalid category ID, the item is added to the uncategorized category. Since `"uncategorized"` is not a valid category ID, it works as expected but not for the reason the programmer probably assumes.

So, one possible problem with my preferred implementation (`category = None`) is that there would be no technically correct way to purposefully put an item in uncategorized as it doesn't have a dedicated `categoryId`.