### PR TITLE
Add new functions and raise an exception when a request fails

### DIFF
--- a/ourgroceries/__init__.py
+++ b/ourgroceries/__init__.py
@@ -285,7 +285,7 @@ class OurGroceries():
         return await self._post(ACTION_ITEM_CHANGE_VALUE, other_payload)
 
     async def _post(self, command, other_payload=None):
-        """Post a command to the API."""
+        """Post a command to the API. Raises an exception if the request failed."""
         if not self._session_key:
             await self.login()
 
@@ -299,5 +299,5 @@ class OurGroceries():
             payload = {**payload, **other_payload}
 
         async with aiohttp.ClientSession(cookies=cookies) as session:
-            async with session.post(YOUR_LISTS, json=payload) as resp:
+            async with session.post(YOUR_LISTS, json=payload, raise_for_status=True) as resp:
                 return await resp.json()

--- a/ourgroceries/__init__.py
+++ b/ourgroceries/__init__.py
@@ -4,6 +4,7 @@ import re
 import json
 import aiohttp
 import logging
+from typing import Optional
 
 from .exceptions import InvalidLoginException
 
@@ -37,6 +38,7 @@ ACTION_ITEM_RENAME = 'changeItemValue'
 ACTION_LIST_CREATE = 'createList'
 ACTION_LIST_REMOVE = 'deleteList'
 ACTION_LIST_RENAME = 'renameList'
+ACTION_LIST_SET_NOTES = 'setListNotes'
 
 ACTION_GET_MASTER_LIST = 'getMasterList'
 ACTION_GET_CATEGORY_LIST = 'getCategoryList'
@@ -66,6 +68,7 @@ ATTR_ITEM_NOTE = 'note'
 ATTR_ITEMS = 'items'
 ATTR_COMMAND = 'command'
 ATTR_TEAM_ID = 'teamId'
+ATTR_LIST_NOTES = 'listNotes'
 
 # properties of returned data
 PROP_LIST = 'list'
@@ -170,6 +173,12 @@ class OurGroceries():
         data = await self._post(ACTION_GET_LIST, other_payload)
         data[PROP_LIST][PROP_ITEMS] = list(map(add_crossed_off_prop, data[PROP_LIST][PROP_ITEMS]))
         return data
+
+    async def create_recipe(self, name) -> Optional[str]:
+        """Create a new recipe and returns the new list ID on success or None if a list with that name already exists."""
+        _LOGGER.debug('ourgroceries create_recipe')
+        result = await self.create_list(name, "RECIPE")
+        return result.get(ATTR_LIST_ID) if result else None
 
     async def create_list(self, name, list_type='SHOPPING'):
         """Create a new shopping list."""
@@ -283,6 +292,15 @@ class OurGroceries():
             ATTR_TEAM_ID: self._team_id,
         }
         return await self._post(ACTION_ITEM_CHANGE_VALUE, other_payload)
+
+    async def set_list_notes(self, list_id: str, notes: str):
+        """Set the notes for a list."""
+        _LOGGER.debug('ourgroceries set_list_notes')
+        other_payload = {
+            ATTR_LIST_ID: list_id,
+            ATTR_LIST_NOTES: notes,
+        }
+        return await self._post(ACTION_LIST_SET_NOTES, other_payload)
 
     async def _post(self, command, other_payload=None):
         """Post a command to the API. Raises an exception if the request failed."""


### PR DESCRIPTION
- Adds a `create_recipe` function that is essentially a wrapper around `create_list` which creates a list of type "RECIPE".
Unlike `create_list` this function returns the list id, not the whole response json. I think this is more straight forward, since that's the only property the user is interested in.
However, I'd understand if you prefer to keep the behavior mostly consistent. In that case let me know and I'll change it to return the whole dict like `create_list`.

- Adds a `set_list_notes` function for setting the notes for a given list.

- Adds `raise_for_status=True` when sending the request to automatically raise a corresponding exception when the request fails. E.g. passing an empty string as list name in `create_list` causes a "400 Bad Request" error to be returned.
Previously this would raise a rather cryptic exception:
`aiohttp.client_exceptions.ContentTypeError: 400, message='Attempt to decode JSON with unexpected mimetype: ', url='https://www.ourgroceries.com/your-lists/'`.
Now, the exception looks like the following, which I find less cryptic and implies something is wrong with the request:
`aiohttp.client_exceptions.ClientResponseError: 400, message='Bad Request', url='https://www.ourgroceries.com/your-lists/'`